### PR TITLE
Hardening: allow running as non root; allow for gossip encryption

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,9 @@ consul_datacenter: SFO01
 consul_log_level: INFO
 consul_ports_http: 8500
 
+# to enable consul gossip encryption simply define a variable:
+# consul_gossip_encryption_key: "o3GQxsj0skowrZamiScm6g=="
+
 ##### CHECKSUMS #####
 consul_checksums:
    # https://releases.hashicorp.com/consul/1.0.0/consul_1.0.0_SHA256SUMS

--- a/tasks/agent.yml
+++ b/tasks/agent.yml
@@ -5,6 +5,16 @@
     dest: "{{ consul_conf_agent_dir }}/agent.json"
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
-    mode: 0644
+    mode: 0640
+  notify:
+    - restart consul-agent
+- name: copy gossip encryption configuration file
+  when: consul_gossip_encryption_key is defined
+  template:
+    src: "encryption.json.j2"
+    dest: "{{ consul_conf_agent_dir }}/encryption.json"
+    owner: "{{ consul_user }}"
+    group: "{{ consul_group }}"
+    mode: 0640
   notify:
     - restart consul-agent

--- a/tasks/install_agent.yml
+++ b/tasks/install_agent.yml
@@ -18,10 +18,13 @@
         - "{{ consul_conf_agent_dir }}"
         - "{{ consul_data_dir }}"
         - "{{ consul_systemd_dir }}"
+        - "{{ consul_os_pid_dir }}"
       file:
         path: "{{ item }}"
         state: directory
-        mode: 0755
+        mode: 0750
+        owner: "{{ consul_user }}"
+        group: "{{ consul_group }}"
 
     - name: download consul
       get_url:
@@ -36,6 +39,8 @@
         src: /tmp/{{consul_zip}}
         dest: '{{consul_bin_dir}}'
         creates: '{{consul_bin_dir}}/consul'
+        group: '{{ consul_group }}'
+        owner: '{{ consul_user }}'
   always:
     - name: cleanup
       file:
@@ -48,7 +53,7 @@
     dest: "{{ consul_systemd_dir }}/consul-agent.service"
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
-    mode: 0644
+    mode: 0640
   notify:
     - restart consul-agent
 

--- a/tasks/install_template.yml
+++ b/tasks/install_template.yml
@@ -16,14 +16,16 @@
       file:
         path: "{{ item }}"
         state: directory
-        mode: 0755
+        mode: 0750
+        owner: "{{ consul_user }}"
+        group: "{{ consul_group }}"
 
     - name: Download consul-template
       get_url:
         url: "{{ consul_template_url }}"
         dest: "/tmp/{{ consul_template_archive }}"
         checksum: "{{ consul_template_checksum }}"
-        mode: 0644
+        mode: 0640
 
     - name: Unarchive consul-template
       unarchive:
@@ -31,6 +33,8 @@
         src: "/tmp/{{ consul_template_archive }}"
         dest: "{{ consul_bin_dir }}"
         creates: "{{ consul_bin_dir }}/consul-template"
+        group: '{{ consul_group }}'
+        owner: '{{ consul_user }}'
 
   always:
     - name: Cleanup
@@ -44,7 +48,7 @@
     dest: "{{ consul_conf_template_dir }}/consul-template.hcl"
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
-    mode: 0644
+    mode: 0640
   notify:
     - restart consul-template
 
@@ -54,7 +58,7 @@
     dest: "{{ consul_systemd_dir }}/consul-template.service"
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
-    mode: 0644
+    mode: 0640
   notify:
     - restart consul-template
 

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -6,6 +6,8 @@
       path: "{{ consul_conf_agent_dir }}"
       state: directory
       mode: 0755
+      owner: "{{ consul_user }}"
+      group: "{{ consul_group }}"
 
   - name: create service definition
     template:

--- a/tasks/template.yml
+++ b/tasks/template.yml
@@ -5,7 +5,7 @@
       file:
         path: "{{ item }}"
         state: directory
-        mode: 0755
+        mode: 0750
       with_items:
         - "{{ consul_conf_template_tmpld_dir }}"
         - "{{ consul_templates_dir }}"
@@ -16,7 +16,7 @@
         dest: "{{ consul_conf_template_tmpld_dir }}/{{ consul_service_template_name }}.hcl"
         owner: "{{ consul_user }}"
         group: "{{ consul_group }}"
-        mode: 0644
+        mode: 0640
       notify:
         - reload consul-template
 
@@ -26,6 +26,6 @@
         dest: "{{ consul_templates_dir }}/{{ consul_service_template_name }}.ctmpl"
         owner: "{{ consul_user }}"
         group: "{{ consul_group }}"
-        mode: 0644
+        mode: 0640
       notify:
         - reload consul-template

--- a/templates/encryption.json.j2
+++ b/templates/encryption.json.j2
@@ -1,0 +1,5 @@
+{
+    "encrypt": "{{ consul_gossip_encryption_key }}",
+    "encrypt_verify_incoming": true,
+    "encrypt_verify_outgoing": true
+}


### PR DESCRIPTION
Hi Tosh,
there were already appropriate vars defined, but some minor enhancements were necessary to actually allow setting up the Consul cluster to run as non-root user. I've also added an option to run the cluster with encrypted gossip communication (https://www.consul.io/docs/agent/encryption.html) with a pre-shared key.
I'm running this in my "lab" (vagrant on laptop) since couple of days. Seems to be working OK.